### PR TITLE
Add varargs and native types support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ for table in qldb_session.list_tables():
 ### See Also
 
 1. [Amazon QLDB Python Driver Tutorial](https://docs.aws.amazon.com/qldb/latest/developerguide/getting-started.python.tutorial.html): In this tutorial, you use the QLDB Driver for Python to create an Amazon QLDB ledger and populate it with tables and sample data.
-2. [Amazon QLDB Python Driver Samples](https://github.com/awslabs/amazon-qldb-driver-python): A DMV based example application which demonstrates how to use QLDB with the QLDB Driver for Python.
+2. [Amazon QLDB Python Driver Samples](https://github.com/aws-samples/amazon-qldb-dmv-sample-python): A DMV based example application which demonstrates how to use QLDB with the QLDB Driver for Python.
 3. QLDB Python driver accepts and returns [Amazon ION](http://amzn.github.io/ion-docs/) Documents. Amazon Ion is a richly-typed, self-describing, hierarchical data serialization format offering interchangeable binary and text representations. For more information read the [ION docs](https://readthedocs.org/projects/ion-python/).
 4. Amazon QLDB supports the [PartiQL](https://partiql.org/) query language. PartiQL provides SQL-compatible query access across multiple data stores containing structured data, semistructured data, and nested data. For more information read the [PartiQL docs](https://partiql.org/docs.html).
 5. Refer the section [Common Errors while using the Amazon QLDB Drivers](https://docs.aws.amazon.com/qldb/latest/developerguide/driver-errors.html) which describes runtime errors that can be thrown by the Amazon QLDB Driver when calling the qldb-session APIs.
@@ -55,7 +55,7 @@ like this instead of the `pip install pyqldb` defined above:
 
 ```
 $ git clone https://github.com/awslabs/amazon-qldb-driver-python
-$ cd driver
+$ cd amazon-qldb-driver-python
 $ virtualenv venv
 ...
 $ . venv/bin/activate
@@ -83,6 +83,18 @@ $ make html
 ```
 
 ## Release Notes
+
+### Release 2.0.0
+
+#### New features:
+* Added Execute methods to PooledQldbDriver
+* Added support for python native types for [execute_statement](https://amazon-qldb-driver-python.readthedocs.io/en/latest/reference/session/pooled_qldb_session.html#pyqldb.session.pooled_qldb_session.PooledQldbSession.execute_statement) parameters
+
+#### Unavoidable breaking changes:
+* In order to be more pythonic, the method signature of [execute_statement](https://amazon-qldb-driver-python.readthedocs.io/en/latest/reference/session/pooled_qldb_session.html#pyqldb.session.pooled_qldb_session.PooledQldbSession.execute_statement) has 
+been changed to receive *args. This is a breaking change for any application 
+that uses 1.0.0-rc.2 version of the driver. Starting v2.0, applications should 
+pass execute_statement parameters as comma separated arguments instead of passing them as a list.
 
 ### Release 1.0.0-rc.2 (October 29, 2019)
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,6 +52,13 @@ Errors
 
    reference/errors/errors
 
+Execution
+~~~~~~~~~
+
+.. toctree::
+   :maxdepth: 3
+
+   reference/execution/index
 
 Session
 ~~~~~~~

--- a/docs/source/reference/execution/executable.rst
+++ b/docs/source/reference/execution/executable.rst
@@ -1,0 +1,8 @@
+====================
+Executable Reference
+====================
+
+.. automodule:: pyqldb.execution.executable
+   :members:
+   :undoc-members:
+

--- a/docs/source/reference/execution/executor.rst
+++ b/docs/source/reference/execution/executor.rst
@@ -2,7 +2,7 @@
 Executor Reference
 ==================
 
-.. automodule:: pyqldb.session.executor
+.. automodule:: pyqldb.execution.executor
    :members:
    :undoc-members:
 

--- a/docs/source/reference/execution/index.rst
+++ b/docs/source/reference/execution/index.rst
@@ -1,0 +1,10 @@
+====================
+Execution References
+====================
+
+.. toctree::
+  :maxdepth: 2
+  :titlesonly:
+  :glob:
+
+  *

--- a/docs/source/reference/transaction/transaction.rst
+++ b/docs/source/reference/transaction/transaction.rst
@@ -5,4 +5,3 @@ Transaction Reference
 .. automodule:: pyqldb.transaction.transaction
    :members:
    :undoc-members:
-

--- a/pyqldb/__init__.py
+++ b/pyqldb/__init__.py
@@ -9,4 +9,4 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-__version__ = '1.0.0-rc.2'
+__version__ = '2.0.0'

--- a/pyqldb/communication/session_client.py
+++ b/pyqldb/communication/session_client.py
@@ -16,8 +16,6 @@ from amazon.ion.simple_types import IonPyBool, IonPyBytes, IonPyDecimal, IonPyDi
 from amazon.ion.simpleion import dumps
 from botocore.exceptions import ClientError
 
-IonValue = (IonPyBool, IonPyBytes, IonPyDecimal, IonPyDict, IonPyFloat, IonPyInt, IonPyList, IonPyNull, IonPySymbol,
-            IonPyText, IonPyTimestamp)
 logger = getLogger(__name__)
 
 
@@ -186,13 +184,12 @@ class SessionClient:
         """
         Send request to start a transaction.
 
-        :rtype: str
-        :return: The transaction ID.
+        :rtype: dict
+        :return: The start transaction response.
         """
         request = {'SessionToken': self.token, 'StartTransaction': {}}
         result = self._send_command(request)
-        transaction_id = result.get('StartTransaction').get('TransactionId')
-        return transaction_id
+        return result.get('StartTransaction')
 
     def _send_command(self, request):
         """

--- a/pyqldb/execution/executable.py
+++ b/pyqldb/execution/executable.py
@@ -1,0 +1,32 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+from abc import ABC, abstractmethod
+
+
+class Executable(ABC):
+    """
+    An abstract base class representing the functionality of execution against QLDB.
+    """
+    @abstractmethod
+    def execute_statement(self, statement, *parameters, retry_indicator):
+        """
+        Implicitly start a transaction, execute the statement, and commit the transaction, retrying up to the
+        retry limit if an OCC conflict or retriable exception occurs. This method must be overridden.
+        """
+        pass
+
+    @abstractmethod
+    def execute_lambda(self, query_lambda, retry_indicator):
+        """
+        Implicitly start a transaction, execute the lambda function, and commit the transaction, retrying up to the
+        retry limit if an OCC conflict or retriable exception occurs. This method must be overridden.
+        """
+        pass

--- a/pyqldb/execution/executor.py
+++ b/pyqldb/execution/executor.py
@@ -33,20 +33,23 @@ class Executor:
         """
         raise LambdaAbortedError
 
-    def execute_statement(self, statement, parameters=[]):
+    def execute_statement(self, statement, *parameters):
         """
         Execute the statement.
 
         :type statement: str
         :param statement: The statement to execute.
 
-        :type parameters: list
-        :param parameters: Optional list of Ion values to fill in parameters of the statement.
+        :type parameters: Variable length argument list
+        :param parameters: Ion values or Python native types that are convertible to Ion for filling in parameters
+                           of the statement.
+
+                           `Details on conversion support and rules <https://ion-python.readthedocs.io/en/latest/amazon.ion.html?highlight=simpleion#module-amazon.ion.simpleion>`_.
 
         :rtype: :py:class:`pyqldb.cursor.stream_cursor.StreamCursor`
         :return: Cursor on the result set of the statement.
 
         :raises TransactionClosedError: When this transaction is closed.
         """
-        cursor = self._transaction.execute_statement(statement, parameters)
+        cursor = self._transaction.execute_statement(statement, *parameters)
         return cursor

--- a/pyqldb/session/base_qldb_session.py
+++ b/pyqldb/session/base_qldb_session.py
@@ -10,8 +10,10 @@
 # and limitations under the License.
 from abc import ABC, abstractmethod
 
+from ..execution.executable import Executable
 
-class BaseQldbSession(ABC):
+
+class BaseQldbSession(Executable, ABC):
     """
     An abstract base class representing a session to a specific ledger within QLDB.
     """
@@ -47,22 +49,6 @@ class BaseQldbSession(ABC):
     def close(self):
         """
         Close this QldbSession. This method must be overridden.
-        """
-        pass
-
-    @abstractmethod
-    def execute_statement(self, statement, parameters, retry_indicator):
-        """
-        Implicitly start a transaction, execute the statement, and commit the transaction, retrying up to the
-        retry limit if an OCC conflict or retriable exception occurs. This method must be overridden.
-        """
-        pass
-
-    @abstractmethod
-    def execute_lambda(self, query_lambda, retry_indicator):
-        """
-        Implicitly start a transaction, execute the lambda function, and commit the transaction, retrying up to the
-        retry limit if an OCC conflict or retriable exception occurs. This method must be overridden.
         """
         pass
 

--- a/pyqldb/session/pooled_qldb_session.py
+++ b/pyqldb/session/pooled_qldb_session.py
@@ -47,7 +47,7 @@ class PooledQldbSession(BaseQldbSession):
             self._is_closed = True
             self._return_session_to_pool(self._qldb_session)
 
-    def execute_statement(self, statement, parameters=[], retry_indicator=lambda execution_attempt: None):
+    def execute_statement(self, statement, *parameters, retry_indicator=lambda execution_attempt: None):
         """
         Calls :py:meth:`pyqldb.session.qldb_session.QldbSession.execute_statement` to implicitly start a transaction,
         execute the statement, and commit the transaction, retrying up to the retry limit if an OCC conflict or
@@ -61,8 +61,11 @@ class PooledQldbSession(BaseQldbSession):
         :type statement: str
         :param statement: The statement to execute.
 
-        :type parameters: list
-        :param parameters: Optional list of Ion values to fill in parameters of the statement.
+        :type parameters: Variable length argument list
+        :param parameters: Ion values or Python native types that are convertible to Ion for filling in parameters
+                           of the statement.
+
+                           `Details on conversion support and rules <https://ion-python.readthedocs.io/en/latest/amazon.ion.html?highlight=simpleion#module-amazon.ion.simpleion>`_.
 
         :type retry_indicator: function
         :param retry_indicator: Optional function called when the transaction execution is about to be retried due to an
@@ -76,10 +79,13 @@ class PooledQldbSession(BaseQldbSession):
 
         :raises SessionClosedError: When this session is closed.
 
-        :raises ClientError: When there is an error communicating with QLDB.
+        :raises ClientError: When there is an error executing against QLDB.
+
+        :raises TypeError: When conversion of native data type (in parameters) to Ion fails due to an unsupported type.
         """
-        return self._invoke_on_session(lambda: self._qldb_session.execute_statement(statement, parameters,
-                                                                                    retry_indicator))
+        return self._invoke_on_session(lambda: self._qldb_session.execute_statement(statement, *parameters,
+                                                                                    retry_indicator=retry_indicator
+                                                                                    ))
 
     def execute_lambda(self, query_lambda, retry_indicator=lambda execution_attempt: None):
         """
@@ -110,7 +116,9 @@ class PooledQldbSession(BaseQldbSession):
 
         :raises SessionClosedError: When this session is closed.
 
-        :raises ClientError: When there is an error communicating with QLDB.
+        :raises ClientError: When there is an error executing against QLDB.
+
+        :raises LambdaAbortedError: If the lambda function calls :py:class:`pyqldb.execution.executor.Executor.abort`.
         """
         return self._invoke_on_session(lambda: self._qldb_session.execute_lambda(query_lambda, retry_indicator))
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
-Sphinx>=2.2.0
-guzzle_sphinx_theme>=0.7.10,<0.8
+Sphinx~=2.2.0
+guzzle_sphinx_theme~=0.7.10
 -rrequirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-amazon.ion==0.5.0
-boto3==1.9.237
-botocore==1.12.237
-ionhash==1.1.0
-pytest==4.6.3
-pytest-cov==2.7.1
+amazon.ion~=0.5.0
+boto3~=1.9.237
+botocore~=1.12.237
+ionhash~=1.1.0
+pytest~=4.6.3
+pytest-cov~=2.7.1

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ import setuptools
 
 ROOT = os.path.join(os.path.dirname(__file__), 'pyqldb')
 VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.a-z\-]+)['"]''')
-requires = ['amazon.ion>=0.5.0',
-            'boto3>=1.9.237',
-            'botocore>=1.12.237',
-            'ionhash>=1.1.0']
+requires = ['amazon.ion>=0.5.0,<0.6',
+            'boto3>=1.9.237,<2',
+            'botocore>=1.12.237,<2',
+            'ionhash>=1.1.0,<2']
 
 
 def get_version():

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -12,12 +12,13 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from pyqldb.errors import LambdaAbortedError
-from pyqldb.session.executor import Executor
+from pyqldb.execution.executor import Executor
 
 MOCK_ERROR_CODE = '500'
 MOCK_MESSAGE = 'foo'
 MOCK_STATEMENT = 'SELECT * FROM foo'
-MOCK_PARAMS = ['foo', 'bar']
+MOCK_PARAMETER_1 = 'foo'
+MOCK_PARAMETER_2 = 'bar'
 MOCK_CLIENT_ERROR_MESSAGE = {'Error': {'Code': MOCK_ERROR_CODE, 'Message': MOCK_MESSAGE}}
 
 
@@ -39,6 +40,6 @@ class TestExecutor(TestCase):
         mock_transaction.execute_statement.return_value = mock_cursor
         executor = Executor(mock_transaction)
 
-        cursor = executor.execute_statement(MOCK_STATEMENT, MOCK_PARAMS)
-        mock_transaction.execute_statement.assert_called_once_with(MOCK_STATEMENT, MOCK_PARAMS)
+        cursor = executor.execute_statement(MOCK_STATEMENT, MOCK_PARAMETER_1, MOCK_PARAMETER_2)
+        mock_transaction.execute_statement.assert_called_once_with(MOCK_STATEMENT, MOCK_PARAMETER_1, MOCK_PARAMETER_2)
         self.assertEqual(cursor, mock_cursor)

--- a/tests/unit/test_pooled_qldb_session.py
+++ b/tests/unit/test_pooled_qldb_session.py
@@ -19,7 +19,8 @@ from pyqldb.errors import SessionClosedError
 MOCK_LEDGER_NAME = 'ledger name'
 MOCK_SESSION_TOKEN = 'session token'
 MOCK_STATEMENT = 'statement'
-MOCK_PARAMETERS = 'parameters'
+MOCK_PARAMETER_1 = 'parameter_1'
+MOCK_PARAMETER_2 = 'parameter_2'
 MOCK_ERROR_CODE = 500
 MOCK_MESSAGE = 'foo'
 
@@ -105,7 +106,8 @@ class TestPooledQldbSession(TestCase):
         retry_indicator = Mock()
         mock_invoke_on_session.return_value = mock_invoke_on_session
         pooled_qldb_session = PooledQldbSession(mock_qldb_session, mock_release_session)
-        result = pooled_qldb_session.execute_statement(MOCK_STATEMENT, MOCK_PARAMETERS, retry_indicator)
+        result = pooled_qldb_session.execute_statement(MOCK_STATEMENT, MOCK_PARAMETER_1, MOCK_PARAMETER_2,
+                                                       retry_indicator=retry_indicator)
         mock_invoke_on_session.assert_called_once()
         self.assertEqual(result, mock_invoke_on_session)
 

--- a/tests/unit/test_qldb_driver.py
+++ b/tests/unit/test_qldb_driver.py
@@ -11,8 +11,8 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
-from botocore.config import Config
 from boto3.session import Session
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from pyqldb.driver.qldb_driver import QldbDriver

--- a/tests/unit/test_session_client.py
+++ b/tests/unit/test_session_client.py
@@ -23,7 +23,7 @@ MOCK_ERROR_CODE = '200'
 MOCK_ERROR_MESSAGE = 'error_message'
 MOCK_ID = 'id'
 MOCK_LEDGER_NAME = 'ledger name'
-MOCK_PARAMETERS = ['parameter1', 'parameter2']
+MOCK_PARAMETERS = ('parameter1', 'parameter2')
 MOCK_STATEMENT = 'statement'
 MOCK_TRANSACTION_ID = 'transaction_id'
 MOCK_TOKEN = 'token'
@@ -197,7 +197,7 @@ class TestSessionClient(TestCase):
         mock_client.return_value = mock_client
         mock_send_command.return_value = MOCK_START_TRANSACTION_RESULT
         session = SessionClient(MOCK_LEDGER_NAME, MOCK_TOKEN, mock_client, MOCK_ID)
-        result = session.start_transaction()
+        result = session.start_transaction().get('TransactionId')
 
         self.assertEqual(result, MOCK_TRANSACTION_ID)
         mock_send_command.assert_called_once_with({'SessionToken': MOCK_TOKEN, 'StartTransaction': {}})


### PR DESCRIPTION
New features:
Added Execute methods to PooledQldbDriver
Added support for python native types for execute_statement parameters

Unavoidable breaking changes:
In order to be more pythonic, the method signature of execute_statement has been changed to receive *args. This is a breaking change for any application that uses 1.0.0-rc.2 version of the driver. Starting v2.0, applications should pass execute_statementparameters as comma separated arguments instead of passing them as a list.

*Issue #, if available:*
#7 
#8 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
