### PR TITLE
Release  v2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ $ make html
 
 ## Release Notes
 
+### Release 2.0.1
+
+* Fixed README to reflect the correct minimum python version required.
+The driver requires Python 3.4 or later, earlier it was mentioned to be 3.x
+
 ### Release 2.0.0
 
 #### New features:

--- a/pyqldb/__init__.py
+++ b/pyqldb/__init__.py
@@ -9,4 +9,4 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'


### PR DESCRIPTION
Added Release notes for v2.0.1

* Fixed README to reflect the correct minimum python version required.
The driver requires Python 3.4 or later, earlier it was mentioned to be 3.x

Bumped Version from 2.0.0 to 2.0.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
