### PR TITLE
Improve session pooling algorithm

### DIFF
--- a/pyqldb/driver/base_qldb_driver.py
+++ b/pyqldb/driver/base_qldb_driver.py
@@ -130,13 +130,6 @@ class BaseQldbDriver(ABC):
         self.close()
 
     @abstractmethod
-    def get_session(self):
-        """
-        Retrieve a QldbSession object. This method must be overridden.
-        """
-        pass
-
-    @abstractmethod
     def execute_lambda(self, query_lambda, retry_indicator):
         """
         Implicitly start a transaction, execute the lambda function, and commit the transaction, retrying up to the

--- a/pyqldb/errors/__init__.py
+++ b/pyqldb/errors/__init__.py
@@ -46,6 +46,12 @@ class SessionPoolEmptyError(Exception):
                          'before retrying.'.format(str(timeout)))
 
 
+class StartTransactionError(Exception):
+    def __init__(self, response):
+        super().__init__('Failed to start transaction')
+        self.response = response
+
+
 def is_occ_conflict_exception(e):
     """
     Is the exception an OccConflictException?


### PR DESCRIPTION


*Description of changes:*

    Earlier, while executing the Transaction, if there
    was an InvalidSessionException thrown from the service,
    the driver would send another request to create a new
    session and retry the Tx with the new session.
    This mechanism did not take advantage of a possibly
    healthy session in the pool and maybe we could have
    avoided creating new session. This change fixes that
    and now, whenever ther eis ISE, the driver will try
    with the next session in the pool. If all the
    sessions in the pool are exhausted, only then the
    driver will create a new session.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
