### PR TITLE
Add support for custom Retry policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,8 @@ Then from a Python interpreter, call the driver and specify the ledger name:
 from pyqldb.driver.qldb_driver import QldbDriver
 
 qldb_driver = QldbDriver(ledger_name='test-ledger')
-qldb_session = qldb_driver.get_session()
 
-for table in qldb_session.list_tables():
+for table in qldb_driver.list_tables():
     print(table)
 ```
 

--- a/docs/source/guide/cookbook.rst
+++ b/docs/source/guide/cookbook.rst
@@ -62,14 +62,14 @@ Importing Driver
 
 .. code-block:: python
 
-   from pyqldb.driver.pooled_qldb_driver import PooledQldbDriver
+   from pyqldb.driver.qldb_driver import QldbDriver
 
 Driver Instantiation
 ********************
 
 .. code-block:: python
 
-    qldb_driver = PooledQldbDriver(ledger_name='vehicle-registration')
+    qldb_driver = QldbDriver(ledger_name='vehicle-registration')
 
 CRUD Operations
 ***************
@@ -103,19 +103,28 @@ Transactions need to be strictly idempotent.
 
 .. Note::
 
-    `pyqldb.driver.pooled_qldb_driver.PooledQldbDriver.execute_lambda` accepts a function
-    that receives instance of :py:class:`pyqldb.execution.executor.Executor`
-    The passed function will be executed within the context of
-    an implicitly created transaction(and session). The transaction is wrapped within
-    an executor instance which will be available within the context
-    passed function. Post execution of the function the transaction will
-    be implicitly committed.
+    :py:meth:`pyqldb.driver.qldb_driver.QldbDriver.execute_lambda` accepts a function that receives instance
+    of :py:class:`pyqldb.execution.executor.Executor` which can be used to execute statements. The instance of
+    :py:class:`pyqldb.execution.executor.Executor` wraps an implicity created transaction.
+    Statements can be executed within the function using :py:meth:`pyqldb.execution.executor.Executor.execute_statement`
+    The transaction will be implicitly committed when the passed function returns.
 
-    `pyqldb.driver.pooled_qldb_driver.PooledQldbDriver.execute_lambda` has an inbuilt
+    :py:meth:`pyqldb.driver.qldb_driver.QldbDriver.execute_lambda` has an inbuilt
     Retry mechanism which retries the transaction in case a Retryable Error
-    occurs (such as Timeout, OCCException). The number of times a transaction is configurable
-    and can be configured by setting property `retry_limit` when initializing PooledQldbDriver.
-    The default value for `retry_limit` is 4.
+    occurs (such as Timeout, OCCException). The number of times a transaction is retried
+    is configurable. The default value for number of retries is 4. The configuration can be
+    changed by passing an instance of :py:class:`pyqldb.config.retry_config.RetryConfig` with
+    `retry_limit` property set to desirable value.
+
+
+.. code-block:: python
+
+    from pyqldb.config.retry_config import RetryConfig
+    from pyqldb.driver.qldb_driver import QldbDriver
+
+    retry_config = RetryConfig(retry_limit=2)
+    qldb_driver = QldbDriver("test-ledger", retry_config=retry_config)
+
 
 Creating Table
 ---------------

--- a/docs/source/guide/getting_started.rst
+++ b/docs/source/guide/getting_started.rst
@@ -20,9 +20,9 @@ To use AmazonQLDB, you must first import the driver and specify the ledger name
 
 .. code-block:: python
 
-   from pyqldb.driver.pooled_qldb_driver import PooledQldbDriver
+   from pyqldb.driver.qldb_driver import QldbDriver
 
-   qldb_driver = PooledQldbDriver(ledger_name='vehicle-registration')
+   qldb_driver = QldbDriver(ledger_name='vehicle-registration')
 
 
 """"""""""""""""""""""
@@ -59,7 +59,7 @@ Reading Documents
         # Transaction committed implicitly on return,
         # no need to explicitly commit transaction
 
-    # pyqldb.driver.pooled_qldb_driver.PooledQldbDriver.execute_lambda accepts
+    # pyqldb.driver.qldb_driver.QldbDriver.execute_lambda accepts
     # a function that receives instance of :py:class:`pyqldb.execution.executor.Executor`
     # The passed function will be executed within the context of
     # an implicitly created transaction(and session). The transaction is wrapped by
@@ -140,11 +140,23 @@ Inserting Documents
     result in latent queries and higher number of OCC Exceptions.
 
 .. Note::
-    `execute_lambda` has an inbuilt Retry mechanism which retries the
-    transaction in case a Retryable Error occurs (such as Timeout, OCCException).
-    The number of times a transaction is configurable and can be configured by setting
-    property `retry_limit` when initializing PooledQldbDriver. The default value for
-    `retry_limit` is 4.
+    :py:meth:`pyqldb.driver.qldb_driver.QldbDriver.execute_lambda` has an inbuilt
+    Retry mechanism which retries the transaction in case a Retryable Error
+    occurs (such as Timeout, OCCException). The number of times a transaction is retried
+    is configurable. The default value for number of retries is 4. The configuration can be
+    changed by passing an instance of :py:class:`pyqldb.config.retry_config.RetryConfig` with
+    `retry_limit` property set to desirable value.
+
+
+.. code-block:: python
+
+    from pyqldb.config.retry_config import RetryConfig
+    from pyqldb.driver.qldb_driver import QldbDriver
+
+    retry_config = RetryConfig(retry_limit=2)
+    qldb_driver = QldbDriver("test-ledger", retry_config=retry_config)
+
+
 
 **For more details on Inserting Documents (eg Inserting Ion documents instead of
 native datatypes), Updating, Deleting - Check the** `Cookbook <cookbook.html#inserting-documents>`_

--- a/docs/source/reference/config/index.rst
+++ b/docs/source/reference/config/index.rst
@@ -1,0 +1,11 @@
+======================
+RetryConfig References
+======================
+
+.. toctree::
+  :maxdepth: 2
+  :titlesonly:
+  :glob:
+
+  *
+

--- a/docs/source/reference/config/retry_config.rst
+++ b/docs/source/reference/config/retry_config.rst
@@ -1,0 +1,28 @@
+=====================
+RetryConfig Reference
+=====================
+
+
+.. automodule:: pyqldb.config.retry_config
+   :members:
+   :undoc-members:
+
+Usage
+-------------------
+.. code-block:: python
+
+
+    from pyqldb.config.retry_config import RetryConfig
+    from pyqldb.driver.qldb_driver import QldbDriver
+
+    # Configuring Retry limit to 2
+    retry_config = RetryConfig(retry_limit=2)
+    qldb_driver = QldbDriver("test-ledger", retry_config=retry_config)
+
+    # Configuring a custom back off which increases delay by 1s for each attempt.
+
+    def custom_backoff(retry_attempt, error, transaction_id):
+        return 1000 * retry_attempt
+
+    retry_config = RetryConfig(retry_limit=2, custom_backoff=custom_backoff)
+    qldb_driver = QldbDriver("test-ledger", retry_config=retry_config)

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -20,3 +20,8 @@ API References
    :maxdepth: 3
 
    execution/index
+
+.. toctree::
+   :maxdepth: 3
+
+   config/retry_config

--- a/pyqldb/config/__init__.py
+++ b/pyqldb/config/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
 # the License. A copy of the License is located at
@@ -8,5 +8,3 @@
 # or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
-
-__version__ = '3.0.0-rc.1'

--- a/pyqldb/config/retry_config.py
+++ b/pyqldb/config/retry_config.py
@@ -1,0 +1,77 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+
+class RetryConfig:
+    """
+    Retry and Backoff Config for QldbDriver
+
+    :type retry_limit: int
+    :param retry_limit: The number of automatic retries for statement executions
+                        using :py:meth:`pyqldb.driver.qldb_driver.QldbDriver.execute_lambda`
+                        when an OCC conflict or retriable exception occurs. This value must not be negative.
+
+    :type base: int
+    :param base: The base number of milliseconds to use in the exponential backoff for operation retries.
+                 Defaults to 10 ms.
+
+    :type custom_backoff: function
+    :param custom_backoff: A custom function that accepts a retry count, error, transaction id and returns the amount
+                           of time to delay in milliseconds. If the result is a non-zero negative value the backoff will
+                           be considered to be zero.
+                           The base option will be ignored if this option is supplied.
+
+    :raises ValueError: When `base` or `retry_limit` are negative.
+    """
+
+    def __init__(self, retry_limit=4, base=10, custom_backoff=None):
+        self._validate_base(base)
+        self._validate_retry_limit(retry_limit)
+        self._base = base
+        self._retry_limit = retry_limit
+        self._custom_backoff = custom_backoff
+
+    @property
+    def retry_limit(self):
+        """
+        The number of automatic retries for statement executions using
+        :py:meth:`pyqldb.driver.qldb_driver.QldbDriver.execute_lambda` when an OCC conflict or
+        retriable exception occurs. This value must not be negative.
+        """
+        return self._retry_limit
+
+    @property
+    def base(self):
+        """
+        The base number of milliseconds to use in the exponential backoff for operation retries.
+        Defaults to 10 ms.
+        """
+        return self._base
+
+    @property
+    def custom_backoff(self):
+        """
+        A custom function that accepts a retry count, error, transaction id and returns the amount
+        of time to delay in milliseconds. If the result is a non-zero negative value the backoff will
+        be considered to be zero and will result in no delay.
+        The base option will be ignored if this option is supplied.
+        """
+        return self._custom_backoff
+
+    @staticmethod
+    def _validate_base(base):
+        if base < 0:
+            raise ValueError("Base cannot be negative")
+
+    @staticmethod
+    def _validate_retry_limit(retry_limit):
+        if retry_limit < 0:
+            raise ValueError("retry_limit cannot be negative")

--- a/pyqldb/errors/__init__.py
+++ b/pyqldb/errors/__init__.py
@@ -47,9 +47,9 @@ class SessionPoolEmptyError(Exception):
 
 
 class StartTransactionError(Exception):
-    def __init__(self, response):
+    def __init__(self, error):
         super().__init__('Failed to start transaction')
-        self.response = response
+        self.error = error
 
 
 def is_occ_conflict_exception(e):

--- a/pyqldb/util/retry.py
+++ b/pyqldb/util/retry.py
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+import random
+import sys
+
+MAX_POW = sys.maxsize.bit_length() - 1
+MAX_BACKOFF = 5000
+
+
+class Retry:
+    """
+    This util class contains helpers for calculating backoff for retry.
+    The class is purely meant for internal use.
+    """
+
+    @staticmethod
+    def calculate_backoff(retry_config, retry_attempt, error, transaction_id):
+        if retry_config.custom_backoff:
+            delay = retry_config.custom_backoff(retry_attempt, error, transaction_id)
+            if delay < 0:
+                delay = 0
+        else:
+            delay = Retry._get_delay_with_equal_jitter(retry_attempt, retry_config)
+
+        return delay
+
+    @staticmethod
+    def _get_delay_with_equal_jitter(retry_attempt, retry_config):
+        capped_retries = min(retry_attempt, MAX_POW)
+        delay_seed = min(retry_config.base * (1 << capped_retries), MAX_BACKOFF)
+        delay = delay_seed / 2 + random.randint(0, delay_seed / 2)
+
+        return delay

--- a/tests/integration/integration_test_base.py
+++ b/tests/integration/integration_test_base.py
@@ -14,7 +14,8 @@ from time import sleep
 
 import boto3
 from botocore.exceptions import ClientError
-from pyqldb.driver.qldb_driver import DEFAULT_TIMEOUT_SECONDS, QldbDriver
+from pyqldb.config.retry_config import RetryConfig
+from pyqldb.driver.qldb_driver import QldbDriver
 
 logger = getLogger(__name__)
 basicConfig(level=INFO)
@@ -68,14 +69,16 @@ class IntegrationTestBase:
                 logger.info('The ledger is deleted')
                 return
 
-    def qldb_driver(self, ledger_name=None, pool_limit=0, time_out=DEFAULT_TIMEOUT_SECONDS, retry_limit=4):
+    def qldb_driver(self, ledger_name=None, max_concurrent_transactions=0, retry_limit=4, custom_backoff=None):
         if ledger_name is not None:
             ledger_name = ledger_name
         else:
             ledger_name = self.ledger_name
 
-        return QldbDriver(ledger_name=ledger_name, region_name=self.region, pool_limit=pool_limit,
-                          timeout=time_out, retry_limit=retry_limit)
+        retry_config = RetryConfig(retry_limit=retry_limit, custom_backoff=custom_backoff)
+
+        return QldbDriver(ledger_name=ledger_name, region_name=self.region,
+                          max_concurrent_transactions=max_concurrent_transactions, retry_config=retry_config)
 
 
 class ThreadThatSavesException(Thread):

--- a/tests/integration/test_session_management.py
+++ b/tests/integration/test_session_management.py
@@ -63,7 +63,12 @@ class TestSessionManagement(TestCase):
 
         # With the time out set to 1 ms, only one thread should go through.
         # The other thread will try to acquire the session, but because it can wait for only 1ms, it will error out.
-        with self.integration_test_base.qldb_driver(pool_limit=1, time_out=0.001) as qldb_driver:
+        with self.integration_test_base.qldb_driver(max_concurrent_transactions=1) as qldb_driver:
+
+            # Overriding pool timeout to 0.001s
+            # Note that this override is purely for testing purpose and is NOT RECOMMENDED for production applications.
+            qldb_driver._timeout = 0.001
+
             thread_1 = ThreadThatSavesException(target=qldb_driver.list_tables, bucket=bucket)
             thread_2 = ThreadThatSavesException(target=qldb_driver.list_tables, bucket=bucket)
 
@@ -81,9 +86,14 @@ class TestSessionManagement(TestCase):
         bucket = Queue()
 
         # Start a pooled driver with pool limit of 1 and default timeout of 30 seconds.
-        with self.integration_test_base.qldb_driver(pool_limit=1, time_out=30) as qldb_driver:
+        with self.integration_test_base.qldb_driver(max_concurrent_transactions=1) as qldb_driver:
             # Start two threads to execute list_tables() concurrently which will hit the session pool limit but
             # will succeed because session is returned to pool before timing out.
+
+            # Overriding pool timeout to 30s
+            # Note that this override is purely for testing purpose and is NOT RECOMMENDED for production applications.
+            qldb_driver._timeout = 30
+
             thread_1 = ThreadThatSavesException(target=qldb_driver.list_tables, bucket=bucket)
             thread_2 = ThreadThatSavesException(target=qldb_driver.list_tables, bucket=bucket)
 

--- a/tests/integration/test_statement_execution.py
+++ b/tests/integration/test_statement_execution.py
@@ -32,6 +32,11 @@ class TestStatementExecution(TestCase):
 
         cls.qldb_driver = cls.integration_test_base.qldb_driver()
 
+        def custom_backoff(retry_attempt, error, txn_id):
+            return 0
+
+        cls.qldb_driver_with_custom_backoff = cls.integration_test_base.qldb_driver(custom_backoff=custom_backoff)
+
         # Create table.
         cls.qldb_driver.execute_lambda(lambda txn:
                                        txn.execute_statement("CREATE TABLE {}".format(TABLE_NAME)))
@@ -86,6 +91,18 @@ class TestStatementExecution(TestCase):
     def test_list_tables(self):
         # When.
         cursor = self.qldb_driver.list_tables()
+
+        # Then.
+        tables = list()
+        for row in cursor:
+            tables.append(row)
+
+        self.assertTrue(TABLE_NAME in tables)
+        self.assertTrue(len(tables) == 1)
+
+    def test_list_tables_custom_backoff(self):
+        # When.
+        cursor = self.qldb_driver_with_custom_backoff.list_tables()
 
         # Then.
         tables = list()

--- a/tests/unit/test_retry_config.py
+++ b/tests/unit/test_retry_config.py
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+from unittest import TestCase
+
+from pyqldb.config.retry_config import RetryConfig
+
+DEFAULT_RETRY_LIMIT = 4
+DEFAULT_BASE = 10
+
+
+class TestRetryConfig(TestCase):
+
+    def test_default_config(self):
+        config = RetryConfig()
+        self.assertEqual(config.retry_limit, DEFAULT_RETRY_LIMIT)
+        self.assertEqual(config.custom_backoff, None)
+        self.assertEqual(config.base, 10)
+
+    def test_config_custom_settings(self):
+        def custom_backoff(retry_attempt, error, txn_id):
+            return 1000
+
+        config = RetryConfig(retry_limit=6, custom_backoff=custom_backoff, base=100)
+        self.assertEqual(config.retry_limit, 6)
+        self.assertEqual(config.custom_backoff, custom_backoff)
+        self.assertEqual(config.base, 100)
+
+    def test_config_with_negative_retry_limit(self):
+        self.assertRaises(ValueError, RetryConfig, retry_limit=-8)
+
+    def test_config_with_negative_base(self):
+        self.assertRaises(ValueError, RetryConfig, base=-10)

--- a/tests/unit/test_retry_util.py
+++ b/tests/unit/test_retry_util.py
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+from unittest import TestCase
+
+from unittest.mock import Mock, patch
+from pyqldb.config.retry_config import RetryConfig
+from pyqldb.util.retry import Retry
+
+
+def custom_backoff(retry_attempt, error, transaction_id):
+    return 1000
+
+def custom_backoff_with_negative_value(retry_attempt, error, transaction_id):
+    return -10
+
+RETRY_CONFIG_WITH_CUSTOM_BACKOFF = RetryConfig(custom_backoff=custom_backoff)
+RETRY_CONFIG_WITH_NEGATIVE_BACKOFF = RetryConfig(custom_backoff=custom_backoff_with_negative_value)
+RETRY_CONFIG_WITH_DEFAULT_BACKOFF = RetryConfig()
+mock_error = Mock()
+
+
+class TestRetryUtil(TestCase):
+
+    def test_config_with_custom_backoff(self):
+        self.assertEqual(Retry.calculate_backoff(RETRY_CONFIG_WITH_CUSTOM_BACKOFF, 1, mock_error, 1), 1000)
+
+    def test_config_with_negative_backoff(self):
+        self.assertEqual(Retry.calculate_backoff(RETRY_CONFIG_WITH_NEGATIVE_BACKOFF, 1, mock_error, 1), 0)
+
+    @patch('pyqldb.util.retry.Retry._get_delay_with_equal_jitter')
+    def test_config_with_default_backoff(self, mock_delay_method):
+        Retry.calculate_backoff(RETRY_CONFIG_WITH_DEFAULT_BACKOFF, 1, mock_error, 1)
+        mock_delay_method.assert_called_once_with(1, RETRY_CONFIG_WITH_DEFAULT_BACKOFF)


### PR DESCRIPTION
*Issue #27 , if available:*

*Description of changes:*

This change allows developers to define their own backoff strategies for retries. The default backoff strategy is also being revised and is exepected to be better suited for common use cases. The custom configurations can be configured while creating a driver instance. The execute_lambda function also accepts retry config which will override the config configured for the driver only for that particular lambda execution.
Also as part of simplifying interfaces, the driver property pool_limit is being rename to max_concurrent_transactions. This change also removes the driver property pool_timeout which means that developers will no longer have to specify pool_timeout.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
