### PR TITLE
Support QLDB shell migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__/
 /docs/build/*
 /build
 /dist
+/venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Add support for obtaining basic server-side statistics on individual statement e
 * `get_consumed_ios` returns a dictionary containing the number of read IO requests for a statement execution.
 * `get_timing_information` returns a dictionary containing the server side processing time in milliseconds for a statement execution.
 * `get_consumed_ios` and `get_timing_information` methods in the `StreamCursor` class are stateful, meaning the statistics returned by them reflect the state at the time of method execution.
+* Add `transaction_id` property in `Executor` to provide the Transaction ID if needed.
+* The `Config` parameter of `QldbDriver` now appends the `user_agent_extra` value instead of overwriting it.
 
 ### Release 3.0.0 (August 20, 2020)
 This is a public and generally available(GA) release of the driver, and this version can be used in production applications.

--- a/pyqldb/driver/qldb_driver.py
+++ b/pyqldb/driver/qldb_driver.py
@@ -31,7 +31,6 @@ logger = getLogger(__name__)
 SERVICE_DESCRIPTION = 'QLDB Driver for Python v{}'.format(__version__)
 SERVICE_NAME = 'qldb-session'
 SERVICE_RETRY = {'max_attempts': 0}
-DEFAULT_CONFIG = Config(user_agent_extra=SERVICE_DESCRIPTION, retries=SERVICE_RETRY)
 DEFAULT_RETRY_CONFIG = RetryConfig()
 
 
@@ -74,7 +73,7 @@ class QldbDriver:
     :param aws_session_token: See [1].
 
     :type config: :py:class:`botocore.config.Config`
-    :param config: See [2]. Note that parameter user_agent_extra will be overwritten.
+    :param config: See [2]. Note that parameter user_agent_extra will be appended and retries will be overwritten.
 
     :type boto3_session: :py:class:`boto3.session.Session`
     :param boto3_session: The boto3 session to create the client with (see [1]). The boto3 session is expected to be
@@ -116,9 +115,14 @@ class QldbDriver:
             if not isinstance(config, Config):
                 raise TypeError('config must be of type botocore.config.Config. Found: {}'
                                 .format(type(config).__name__))
-            self._config = config.merge(DEFAULT_CONFIG)
+            self._config = config
+            self._config.retries = SERVICE_RETRY
+            if self._config.user_agent_extra:
+                self._config.user_agent_extra = ' '.join([SERVICE_DESCRIPTION, self._config.user_agent_extra])
+            else:
+                self._config.user_agent_extra = SERVICE_DESCRIPTION
         else:
-            self._config = DEFAULT_CONFIG
+            self._config = Config(user_agent_extra=SERVICE_DESCRIPTION, retries=SERVICE_RETRY)
 
         if retry_config is not None:
             if not isinstance(retry_config, RetryConfig):

--- a/pyqldb/execution/executor.py
+++ b/pyqldb/execution/executor.py
@@ -25,6 +25,13 @@ class Executor:
     def __init__(self, transaction):
         self._transaction = transaction
 
+    @property
+    def transaction_id(self):
+        """
+        The **read-only** ID of this transaction.
+        """
+        return self._transaction.transaction_id
+
     def abort(self):
         """
         Abort the transaction and roll back any changes.

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -26,9 +26,11 @@ MOCK_CLIENT_ERROR_MESSAGE = {'Error': {'Code': MOCK_ERROR_CODE, 'Message': MOCK_
 class TestExecutor(TestCase):
 
     def test_Executor(self, mock_transaction):
+        mock_transaction.transaction_id = 'txnId'
         executor = Executor(mock_transaction)
 
         self.assertEqual(executor._transaction, mock_transaction)
+        self.assertEqual(executor.transaction_id, 'txnId')
 
     def test_abort(self, mock_transaction):
         executor = Executor(mock_transaction)


### PR DESCRIPTION
- Allow the transaction id to be obtained during a transaction
- Append any custom user agent strings instead of replacing it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
