### PR TITLE
Return none if no query stats from SDK

### DIFF
--- a/docs/source/reference/session/base_qldb_session.rst
+++ b/docs/source/reference/session/base_qldb_session.rst
@@ -1,8 +1,0 @@
-=========================
-BaseQldbSession Reference
-=========================
-
-.. automodule:: pyqldb.session.base_qldb_session
-   :members:
-   :undoc-members:
-

--- a/docs/source/reference/session/pooled_qldb_session.rst
+++ b/docs/source/reference/session/pooled_qldb_session.rst
@@ -1,7 +1,0 @@
-===========================
-PooledQldbSession Reference
-===========================
-
-.. automodule:: pyqldb.session.pooled_qldb_session
-   :members:
-   :undoc-members:

--- a/pyqldb/cursor/buffered_cursor.py
+++ b/pyqldb/cursor/buffered_cursor.py
@@ -40,18 +40,20 @@ class BufferedCursor:
 
     def get_consumed_ios(self):
         """
-        Return a dictionary containing the total amount of IO requests for a statement's execution.
+        Return a dictionary containing the total amount of IO requests for a statement execution. Return None if there
+        were no read IOs for a statement execution.
 
-        :rtype: dict
-        :return: The amount of read IO requests for a statement's execution.
+        :rtype: dict/None
+        :return: The amount of read IO requests for a statement execution.
         """
         return self._consumed_ios
 
     def get_timing_information(self):
         """
-        Return a dictionary containing the total amount of processing time for a statement's execution.
+        Return a dictionary containing the total amount of processing time for a statement execution. Return None if
+        there was no timing information for a statement execution.
 
-        :rtype: dict
-        :return: The amount of processing time in milliseconds for a statement's execution.
+        :rtype: dict/None
+        :return: The amount of processing time in milliseconds for a statement execution.
         """
         return self._timing_information

--- a/pyqldb/cursor/read_ahead_cursor.py
+++ b/pyqldb/cursor/read_ahead_cursor.py
@@ -26,7 +26,7 @@ class ReadAheadCursor(StreamCursor):
     size `read_ahead` and fetch results asynchronously to fill the queue.
 
     :type statement_result: dict
-    :param statement_result: The initial result set data dictionary of the statement's execution.
+    :param statement_result: The initial result set data dictionary of the statement execution.
 
     :type session: :py:class:`pyqldb.communication.session_client.SessionClient`
     :param session: The parent session that represents the communication channel to QLDB.

--- a/pyqldb/cursor/stream_cursor.py
+++ b/pyqldb/cursor/stream_cursor.py
@@ -18,7 +18,7 @@ class StreamCursor:
     An iterable class representing a stream cursor on a statement's result set.
 
     :type statement_result: dict
-    :param statement_result: The initial result set data dictionary of the statement's execution.
+    :param statement_result: The initial result set data dictionary of the statement execution.
 
     :type session: :py:class:`pyqldb.communication.session_client.SessionClient`
     :param session: The parent session that represents the communication channel to QLDB.
@@ -78,21 +78,24 @@ class StreamCursor:
 
     def get_consumed_ios(self):
         """
-        Return a dictionary containing the accumulated amount of IO requests for a statement's execution.
+        Return a dictionary containing the accumulated amount of IO requests for a statement execution. Return None if
+        there were no read IOs for a statement execution.
 
-        :rtype: dict
-        :return: The amount of read IO requests for a statement's execution.
+        :rtype: dict/None
+        :return: The amount of read IO requests for a statement execution.
         """
-        return {'ReadIOs': self._read_ios}
+        return None if self._read_ios is None else {'ReadIOs': self._read_ios}
 
     def get_timing_information(self):
         """
-        Return a dictionary containing the accumulated amount of processing time for a statement's execution.
+        Return a dictionary containing the accumulated amount of processing time for a statement execution. Return None
+        if there was no timing information for a statement execution.
 
-        :rtype: dict
-        :return: The amount of processing time in milliseconds for a statement's execution.
+        :rtype: dict/None
+        :return: The amount of processing time in milliseconds for a statement execution.
         """
-        return {'ProcessingTimeMilliseconds': self._processing_time_milliseconds}
+        return None if self._processing_time_milliseconds is None else {'ProcessingTimeMilliseconds':
+                                                                            self._processing_time_milliseconds}
 
     def _are_there_more_results(self):
         """

--- a/pyqldb/driver/qldb_driver.py
+++ b/pyqldb/driver/qldb_driver.py
@@ -88,7 +88,7 @@ class QldbDriver:
 
     :raises TypeError: When config is not an instance of :py:class:`botocore.config.Config`.
                        When boto3_session is not an instance of :py:class:`boto3.session.Session`.
-                       When retry_config is not an instance of :py:class:pyqldb.config.retry_config.RetryConfig.
+                       When retry_config is not an instance of :py:class:`pyqldb.config.retry_config.RetryConfig`.
 
     :raises ValueError: When `max_concurrent_transactions` exceeds the limit set by the client.
                         When `max_concurrent_transactions` is negative.

--- a/tests/unit/helper_functions.py
+++ b/tests/unit/helper_functions.py
@@ -11,8 +11,8 @@
 
 from unittest.mock import MagicMock
 
-from pyqldb.cursor.buffered_cursor import BufferedCursor
 from pyqldb.cursor.stream_cursor import StreamCursor
+
 
 def generate_statement_result(read_io, write_io, processing_time, next_page_token, is_first_page,
                               values=[{'IonBinary': 1}]):
@@ -35,21 +35,27 @@ def generate_statement_result(read_io, write_io, processing_time, next_page_toke
     return statement_result
 
 
-def assert_query_stats(class_instance, buffered_cursor, read_ios_assert, write_ios_assert, timing_information_assert):
+def assert_query_stats(test_case, buffered_cursor, read_ios_assert, write_ios_assert, timing_information_assert):
     """
     Asserts the query statistics returned by the cursor.
     """
     consumed_ios = buffered_cursor.get_consumed_ios()
-    class_instance.assertIsNotNone(consumed_ios)
-    read_ios = consumed_ios.get('ReadIOs')
+    if read_ios_assert is not None:
+        test_case.assertIsNotNone(consumed_ios)
+        read_ios = consumed_ios.get('ReadIOs')
 
-    class_instance.assertEqual(read_ios, read_ios_assert)
+        test_case.assertEqual(read_ios, read_ios_assert)
+    else:
+        test_case.assertEqual(consumed_ios, None)
 
     timing_information = buffered_cursor.get_timing_information()
-    class_instance.assertIsNotNone(timing_information)
-    processing_time_milliseconds = timing_information.get('ProcessingTimeMilliseconds')
+    if timing_information_assert is not None:
+        test_case.assertIsNotNone(timing_information)
+        processing_time_milliseconds = timing_information.get('ProcessingTimeMilliseconds')
 
-    class_instance.assertEqual(processing_time_milliseconds, timing_information_assert)
+        test_case.assertEqual(processing_time_milliseconds, timing_information_assert)
+    else:
+        test_case.assertEqual(timing_information_assert, None)
 
 
 def create_stream_cursor(mock_session, mock_statement_result_execute, mock_statement_result_fetch):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
-Updated `get_consumed_ios` and `get_timing_information` methods to return None if there were no query stats.
-Removed unused doc template files 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
