### PR TITLE
Update GitHub actions to run on v2.x branch

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, v2.x ]
 
 jobs:
   build:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently the GitHub actions on `v2.x` branch doesn't run because we did not specify the `v2.x` branch for pull requests. Added the branch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
