### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+
+    ignore:
+      - dependency-name: "amazon.ion"
+      - dependency-name: "ionhash"
+      - dependency-name: "boto3"
+      - dependency-name: "botocore"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,14 @@ amazon.ion~=0.7.0
 boto3~=1.16.56
 botocore~=1.19.56
 ionhash~=1.1.0
+
 pytest~=4.6.3
 pytest-cov~=2.7.1
 pytest-subtests~=0.3.0
+
+# Indirect dependencies
+jmespath~=0.9.0
+python-dateutil~=2.8.1
+s3transfer~=0.3.7
+six~=1.15.0
+urllib3~=1.26.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
+# Direct dependencies
 amazon.ion~=0.7.0
 boto3~=1.16.56
 botocore~=1.19.56
 ionhash~=1.1.0
 
+# Testing dependencies
 pytest~=4.6.3
 pytest-cov~=2.7.1
 pytest-subtests~=0.3.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add Dependabot to look for outdated indirect dependencies and to automatically create PRs for them. Verified this on a [fork](https://github.com/justing-bq/amazon-qldb-driver-python/pulls).

I retrieved the indirect dependencies by:
1. Setting up virtual environment
2. Download the direct dependencies
3. Call `pip freeze` to list all dependencies (direct & indirect)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
