### PR TITLE
Bump AWS SDK to support CapacityExceededException

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 amazon.ion~=0.7.0
-boto3~=1.16.56
-botocore~=1.19.56
+boto3~=1.17.5
+botocore~=1.20.5
 ionhash~=1.1.0
 pytest~=4.6.3
 pytest-cov~=2.7.1

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ import setuptools
 ROOT = os.path.join(os.path.dirname(__file__), 'pyqldb')
 VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.a-z\-]+)['"]''')
 requires = ['amazon.ion>=0.7.0,<1',
-            'boto3>=1.16.56,<2',
-            'botocore>=1.19.56,<2',
+            'boto3>=1.17.5,<2',
+            'botocore>=1.20.5,<2',
             'ionhash>=1.1.0,<2']
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CapacityExceededException is a new exception introduced by the AWS SDK. It has 503 error code which the driver currently supports.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
