### PR TITLE
Bump ionhash version to support plain Python strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Release 3.2.1
+This release is to update ionhash Python package from 1.1.0 to 1.2.0.
+
+#### Bug Fixes:
+* Fixed bug which leads to attributeError when using plain python strings in QLDB driver.
+
 ### Release 3.2.0
 This release is focused on improving the retry logic, optimizing it and handling more possible failures.
 

--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -104,7 +104,7 @@ You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 02110-1301
-** ionhash; version 1.1.0 -- https://pypi.org/project/ionhash/
+** ionhash; version 1.2.0 -- https://pypi.org/project/ionhash/
 Ion Hash Python
 Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 

--- a/pyqldb/__init__.py
+++ b/pyqldb/__init__.py
@@ -9,4 +9,4 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-__version__ = '3.2.0'
+__version__ = '3.2.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 amazon.ion~=0.7.0
 boto3~=1.17.5
 botocore~=1.20.5
-ionhash~=1.1.0
+ionhash~=1.2.0
 pytest~=4.6.3
 pytest-cov~=2.7.1
 pytest-subtests~=0.3.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.a-z\-]+)['"]''')
 requires = ['amazon.ion>=0.7.0,<1',
             'boto3>=1.17.5,<2',
             'botocore>=1.20.5,<2',
-            'ionhash>=1.1.0,<2']
+            'ionhash>=1.2.0,<2']
 
 
 def get_version():


### PR DESCRIPTION
*Issue #, if available:*

Customer encountered attributeError when using plain python strings in QLDB driver. This happened when adding a new field with a python string value and writing the document back to the table then ionhash would throw an exception.

*Description of changes:*

Ion team has released the fix for the issue: https://github.com/amzn/ion-hash-python/releases/tag/v1.2.0.
Update ionhash Python package from 1.1.0 to 1.2.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
