### PR TITLE
Pin docutils version to 0.17.1 to fix doc build

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,3 @@
 Sphinx~=2.2.0
+docutils==0.17.1
 guzzle_sphinx_theme~=0.7.10


### PR DESCRIPTION
*Description of changes:*
The `docutils v0.18` is causing docs build failures, pinning it to previous working version `0.17.1` to fix doc build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
