### PR TITLE
Replaced ledger suffix for integration test workflow with short git s…

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -47,4 +47,6 @@ jobs:
       run: |
         pip install pytest
         pytest tests/unit
-        pytest tests/integration --ledger_suffix ${{ matrix.python-version }}-${{ matrix.os }}
+        GITHUB_SHA_SHORT=$(git rev-parse --short $GITHUB_SHA)
+        pytest tests/integration --ledger_suffix ${{ strategy.job-index }}-$GITHUB_SHA_SHORT
+      shell: bash


### PR DESCRIPTION
Fix workflow conflicts by replacing the ledger suffix with the git short SHA and matrix index.

*Description of changes:*
The integration tests create, modify, and delete real QLDB ledgers. With just the OS and python version as a ledger suffix, it is possible for multiple workflows running at the same time to attempt to create/modify the same ledger. This change replaces the suffix with a combination of the git short SHA, and the matrix index to prevent conflicts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
