### PR TITLE
Prepare release 3.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Release 3.2.3
+
+This release pins the Amazon Ion library to a compatible version.
+
+#### Bug Fixes:
+* Pinned the version of amazon.ion to 0.9.3, as later versions are incompatible with this driver.
+
 ### Release 3.2.2
 
 This release is to update ionhash Python package from 1.2.0 to 1.2.1.

--- a/pyqldb/__init__.py
+++ b/pyqldb/__init__.py
@@ -9,4 +9,4 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-__version__ = '3.2.2'
+__version__ = '3.2.3'


### PR DESCRIPTION
*Issue #, if available:*
#164

*Description of changes:*
This ensures the Amazon Ion library is pinned to a version which still
has the `Enum` type.

To keep up with Amazon Ion, we'll likely have to do a major or minor
version bump.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
