### PR TITLE
chore: remove EoL Python 3.7 from test matrix and other CI improvements

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -17,11 +17,11 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
-    strategy: 
+    strategy:
       max-parallel: 6
-      matrix : 
+      matrix :
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: us-east-2
         role-to-assume: arn:aws:iam::264319671630:role/GitHubActionsOidc

--- a/pyqldb/util/retry.py
+++ b/pyqldb/util/retry.py
@@ -37,6 +37,6 @@ class Retry:
     def _get_delay_with_equal_jitter(retry_attempt, retry_config):
         capped_retries = min(retry_attempt, MAX_POW)
         delay_seed = min(retry_config.base * (1 << capped_retries), MAX_BACKOFF)
-        delay = delay_seed / 2 + random.randint(0, delay_seed / 2)
+        delay = delay_seed / 2 + random.randint(0, int(delay_seed / 2))
 
         return delay


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
- fix: force int type for random.randint() per deprecation warning from Python 3.10 onwards and unsupported from 3.12
- chore: bump github action aws-actions/configure-aws-credentials@v4
- chore: bump Github actions for CodeQL
- chore: remove EoL Python 3.7 from test matrix as it has [reached end-of-life on 2023-06-27](https://devguide.python.org/versions/).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
