### PR TITLE
WIP: Test CI with Python 3.11, 3.12

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 6
       matrix :
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python<=3.11
 amazon.ion>=0.7.0,<=0.9.3   # pinned per GitHub issue #164
 boto3~=1.28.79
 botocore~=1.31.79

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python<=3.11
+python_version<=3.11
 amazon.ion>=0.7.0,<=0.9.3   # pinned per GitHub issue #164
 boto3~=1.28.79
 botocore~=1.31.79


### PR DESCRIPTION
Suspect Python 3.12 will experience issues with OCC

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
